### PR TITLE
Add /ethprice API endpoint to fetch Ethereum price

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,13 @@
 const express = require('express');
-const app = express();
-const port = 3000;
+const ethPriceRoutes = require('./src/routes/ethPriceRoutes');
 
-app.get('/', (req, res) => {
-  res.send('Hello World!');
-});
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use('/api', ethPriceRoutes);
 
 app.listen(port, () => {
-  console.log(`Listening on http://localhost:${port}`);
-}); 
+  console.log(`Server running on port ${port}`);
+});
+
+module.exports = app;

--- a/app.js
+++ b/app.js
@@ -1,11 +1,10 @@
 const express = require('express');
-const ethPriceRoutes = require('./src/routes/ethPriceRoutes');
-
 const app = express();
-const port = process.env.PORT || 3000;
+const ethPriceRoutes = require('./src/routes/ethPriceRoutes');
 
 app.use('/api', ethPriceRoutes);
 
+const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Server running on port ${port}`);
 });

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "express-hello-world",
   "version": "1.0.0",
-  "description": "一个简单的 Express Hello World 应用",
+  "description": "Express application with ETH price endpoint",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "jest"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "node-fetch": "^2.6.1"
+  },
+  "devDependencies": {
+    "jest": "^27.0.0",
+    "supertest": "^6.1.6"
   }
-} 
+}

--- a/src/controllers/ethPriceController.js
+++ b/src/controllers/ethPriceController.js
@@ -1,20 +1,14 @@
-const { fetchEthPrice } = require('../services/ethPriceService');
+const EthPriceService = require('../services/ethPriceService');
 
-async function getEthPrice(req, res) {
+class EthPriceController {
+  static async getEthPrice(req, res) {
     try {
-        const price = await fetchEthPrice();
-        res.json({ 
-            currency: 'USD', 
-            price: price 
-        });
+      const ethPrice = await EthPriceService.getEthPrice();
+      res.json({ price: ethPrice });
     } catch (error) {
-        res.status(500).json({ 
-            error: 'Unable to fetch ETH price', 
-            details: error.message 
-        });
+      res.status(500).json({ error: error.message });
     }
+  }
 }
 
-module.exports = {
-    getEthPrice
-};
+module.exports = EthPriceController;

--- a/src/controllers/ethPriceController.js
+++ b/src/controllers/ethPriceController.js
@@ -1,0 +1,14 @@
+const EthPriceService = require('../services/ethPriceService');
+
+class EthPriceController {
+  static async getEthPrice(req, res) {
+    try {
+      const price = await EthPriceService.getEthPriceInUSD();
+      res.json({ price });
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  }
+}
+
+module.exports = EthPriceController;

--- a/src/controllers/ethPriceController.js
+++ b/src/controllers/ethPriceController.js
@@ -1,14 +1,20 @@
-const EthPriceService = require('../services/ethPriceService');
+const { fetchEthPrice } = require('../services/ethPriceService');
 
-class EthPriceController {
-  static async getEthPrice(req, res) {
+async function getEthPrice(req, res) {
     try {
-      const price = await EthPriceService.getEthPriceInUSD();
-      res.json({ price });
+        const price = await fetchEthPrice();
+        res.json({ 
+            currency: 'USD', 
+            price: price 
+        });
     } catch (error) {
-      res.status(500).json({ error: error.message });
+        res.status(500).json({ 
+            error: 'Unable to fetch ETH price', 
+            details: error.message 
+        });
     }
-  }
 }
 
-module.exports = EthPriceController;
+module.exports = {
+    getEthPrice
+};

--- a/src/routes/ethPriceRoutes.js
+++ b/src/routes/ethPriceRoutes.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const EthPriceController = require('../controllers/ethPriceController');
+const { getEthPrice } = require('../controllers/ethPriceController');
 
 const router = express.Router();
 
-router.get('/ethprice', EthPriceController.getEthPrice);
+router.get('/ethprice', getEthPrice);
 
 module.exports = router;

--- a/src/routes/ethPriceRoutes.js
+++ b/src/routes/ethPriceRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const EthPriceController = require('../controllers/ethPriceController');
+
+const router = express.Router();
+
+router.get('/ethprice', EthPriceController.getEthPrice);
+
+module.exports = router;

--- a/src/routes/ethPriceRoutes.js
+++ b/src/routes/ethPriceRoutes.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const { getEthPrice } = require('../controllers/ethPriceController');
+const EthPriceController = require('../controllers/ethPriceController');
 
 const router = express.Router();
 
-router.get('/ethprice', getEthPrice);
+router.get('/ethprice', EthPriceController.getEthPrice);
 
 module.exports = router;

--- a/src/services/ethPriceService.js
+++ b/src/services/ethPriceService.js
@@ -1,0 +1,16 @@
+const fetch = require('node-fetch');
+
+class EthPriceService {
+  static async getEthPriceInUSD() {
+    try {
+      const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd');
+      const data = await response.json();
+      return data.ethereum.usd;
+    } catch (error) {
+      console.error('Error fetching ETH price:', error);
+      throw new Error('Unable to fetch ETH price');
+    }
+  }
+}
+
+module.exports = EthPriceService;

--- a/src/services/ethPriceService.js
+++ b/src/services/ethPriceService.js
@@ -1,16 +1,23 @@
 const fetch = require('node-fetch');
 
-class EthPriceService {
-  static async getEthPriceInUSD() {
+const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3/simple/price';
+
+async function fetchEthPrice() {
     try {
-      const response = await fetch('https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd');
-      const data = await response.json();
-      return data.ethereum.usd;
+        const response = await fetch(`${COINGECKO_API_URL}?ids=ethereum&vs_currencies=usd`);
+        
+        if (!response.ok) {
+            throw new Error('Failed to fetch ETH price');
+        }
+
+        const data = await response.json();
+        return data.ethereum.usd;
     } catch (error) {
-      console.error('Error fetching ETH price:', error);
-      throw new Error('Unable to fetch ETH price');
+        console.error('Error fetching ETH price:', error.message);
+        throw error;
     }
-  }
 }
 
-module.exports = EthPriceService;
+module.exports = {
+    fetchEthPrice
+};

--- a/src/services/ethPriceService.js
+++ b/src/services/ethPriceService.js
@@ -1,23 +1,23 @@
 const fetch = require('node-fetch');
 
-const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3/simple/price';
-
-async function fetchEthPrice() {
+class EthPriceService {
+  static async getEthPrice() {
+    const COINGECKO_API_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd';
+    
     try {
-        const response = await fetch(`${COINGECKO_API_URL}?ids=ethereum&vs_currencies=usd`);
-        
-        if (!response.ok) {
-            throw new Error('Failed to fetch ETH price');
-        }
-
-        const data = await response.json();
-        return data.ethereum.usd;
+      const response = await fetch(COINGECKO_API_URL);
+      
+      if (!response.ok) {
+        throw new Error('Unable to fetch Ethereum price');
+      }
+      
+      const data = await response.json();
+      return data.ethereum.usd;
     } catch (error) {
-        console.error('Error fetching ETH price:', error.message);
-        throw error;
+      console.error('Error fetching ETH price:', error);
+      throw new Error('Failed to retrieve Ethereum price');
     }
+  }
 }
 
-module.exports = {
-    fetchEthPrice
-};
+module.exports = EthPriceService;

--- a/tests/ethPriceEndpoint.test.js
+++ b/tests/ethPriceEndpoint.test.js
@@ -1,19 +1,13 @@
 const request = require('supertest');
 const app = require('../app');
-const { fetchEthPrice } = require('../src/services/ethPriceService');
-
-jest.setTimeout(10000); // Increase timeout for network request
 
 describe('ETH Price Endpoint', () => {
-    it('should return the current ETH price', async () => {
-        const response = await request(app).get('/api/ethprice');
-        
-        expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('currency', 'USD');
-        expect(response.body).toHaveProperty('price');
-        
-        // Price should be a positive number
-        expect(typeof response.body.price).toBe('number');
-        expect(response.body.price).toBeGreaterThan(0);
-    });
+  it('should return a valid ETH price', async () => {
+    const response = await request(app).get('/api/ethprice');
+    
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty('price');
+    expect(typeof response.body.price).toBe('number');
+    expect(response.body.price).toBeGreaterThan(0);
+  });
 });

--- a/tests/ethPriceEndpoint.test.js
+++ b/tests/ethPriceEndpoint.test.js
@@ -1,13 +1,19 @@
 const request = require('supertest');
 const app = require('../app');
+const { fetchEthPrice } = require('../src/services/ethPriceService');
+
+jest.setTimeout(10000); // Increase timeout for network request
 
 describe('ETH Price Endpoint', () => {
-  it('should return ETH price in USD', async () => {
-    const response = await request(app).get('/api/ethprice');
-    
-    expect(response.statusCode).toBe(200);
-    expect(response.body).toHaveProperty('price');
-    expect(typeof response.body.price).toBe('number');
-    expect(response.body.price).toBeGreaterThan(0);
-  }, 10000);  // Increased timeout for external API call
+    it('should return the current ETH price', async () => {
+        const response = await request(app).get('/api/ethprice');
+        
+        expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('currency', 'USD');
+        expect(response.body).toHaveProperty('price');
+        
+        // Price should be a positive number
+        expect(typeof response.body.price).toBe('number');
+        expect(response.body.price).toBeGreaterThan(0);
+    });
 });

--- a/tests/ethPriceEndpoint.test.js
+++ b/tests/ethPriceEndpoint.test.js
@@ -1,0 +1,13 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('ETH Price Endpoint', () => {
+  it('should return ETH price in USD', async () => {
+    const response = await request(app).get('/api/ethprice');
+    
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toHaveProperty('price');
+    expect(typeof response.body.price).toBe('number');
+    expect(response.body.price).toBeGreaterThan(0);
+  }, 10000);  // Increased timeout for external API call
+});


### PR DESCRIPTION
## Description
Adds a new `/ethprice` API endpoint to fetch the current price of Ethereum in USD from CoinGecko.

## Type of Change
- [x] New Feature
- [ ] Bug Fix
- [ ] Breaking Change
- [ ] Documentation Update

## Related Issues
- No specific issue referenced

## Checklist
- [x] I have tested my changes
- [ ] Code follows project's coding style
- [ ] Updated documentation (if applicable)
- [ ] Added tests for new functionality

## Testing Done
- Manually tested the `/ethprice` endpoint
- Verified price retrieval from CoinGecko API
- Confirmed correct response format

## Implementation Details
- Endpoint will return current ETH/USD price
- Uses CoinGecko API for price retrieval